### PR TITLE
1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - reverse / flip the matrix method added
 - `comparseobject` deprecated in favor of `compare`
-- `concatenate`, `diagonal`, `reshape`, `transpose` and `flatten` are vectorized now
+- `concatenate`, `diagonal`, `reshape`, `transpose` and `flatten` are vectorized
+  now
+- `transpose` bug fixed `"'double' is not a subtype of type 'int'"`
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,19 @@
 ## 1.0.4
 
-+  reverse / flip the matrix method added
+- reverse / flip the matrix method added
+- `comparseobject` deprecated in favor of `compare`
 
 ## 1.0.3
 
-+ Fixed slice type issue
+- Fixed slice type issue
 
 ## 1.0.2
 
-+ fix slice function, update test file (@DavidBrynnHouse)
+- fix slice function, update test file (@DavidBrynnHouse)
 
 ## 1.0.1
 
-+ 2d array slicing
+- 2d array slicing
 
 ## 1.0.0
 
@@ -20,32 +21,32 @@ Null and Safety added
 
 ## 0.0.8
 
-+ big update
+- big update
 
 ## 0.0.7
 
-+ matrix `min()`, `max()` operations added
+- matrix `min()`, `max()` operations added
 
 ## 0.0.6
 
-+ small bugs fixed
+- small bugs fixed
 
 ## 0.0.5
 
-+ added  2d matrix `concatenate()`
+- added 2d matrix `concatenate()`
 
 ## 0.0.4
 
-+ added extension support on list or matrix
+- added extension support on list or matrix
 
 ## 0.0.3
 
-+ new README.md
+- new README.md
 
 ## 0.0.2
 
-+ 3 new operations added
+- 3 new operations added
 
 ## 0.0.1
 
-+ Matrix2d released with 13 array operations.
+- Matrix2d released with 13 array operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - reverse / flip the matrix method added
 - `comparseobject` deprecated in favor of `compare`
+- `concatenate`, `diagonal`, `reshape`, `transpose` and `flatten` are vectorized now
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
++  reverse / flip the matrix method added
+
 ## 1.0.3
 
 + Fixed slice type issue

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ print(list.diagonal);
 ```
 
 <hr>
-<h2>compare object</h2>
+<h2>compare</h2>
 
 ```dart
 var list = [[1,1,1],[2,2,2],[3,3,3]];

--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ Matrix 2D you can perform matrix operations such as addition, subtraction, multi
 - `diagonal(list)` To find a diagonal element from a given matrix and gives output as one dimensional matrix.
 - `fill(row,cols,object)` Just like `zeros()` and `ones` this function will return a new array of given shape, with given object(anything btw strings too)
 
-* `compareobject(list,operation,obj)` compare values inside an array with given object and operations. function will return a new boolen array
+* `compareobject(list,operation,obj)` compare values inside an array with given object and operations. function will return a new boolen array (this function is deprecated in favor of `compare`)
 
-* `concatenate(listA,listB,{axis})` Concatenation refers to joining. This function is used to join two arrays of the same shape along a specified axis. The function takes the following parameters.Axis along which arrays have to be joined. Default is 0 _concatenation of n number of arrays comming soon....._
+* `concatenate(listA,listB,{axis})` Concatenation refers to joining. This function is used to join two arrays of the same shape along a specified axis. The function takes the following parameters.Axis along which arrays have to be joined. Default is 0
 
 * `min(list,{axis})` Functions, used to find the minimum value for any given array
 
 * `max(list,{axis})` Functions, used to find the maximum value for any given array
 
 * `slice(list (List<List>), row_index [start, stop*], column_index [start, stop*]*)` Function used to slice two-dimensional arrays . (_column_index_ and _stop_ not required )
+
+* `reverse(list,{axis})` Function used to reverse the array along the given axis. The function takes the following parameters.Axis along which the array is to be flipped. Default is 0
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/n4ze3m/matrix2d/actions/workflows/ci.yml/badge.svg)](https://github.com/n4ze3m/matrix2d/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/github/license/n4ze3m/matrix2d)](https://github.com/n4ze3m/matrix2d/blob/master/LICENSE)
 
-Matrix 2D you can perform matrix operations such as addition, subtraction, multiplication, and more in dart. It is a simple and easy to use library inspired from python's numpy library.
+With Matrix 2D, you can perform matrix operations such as addition, subtraction, and multiplication in Dart. It is a simple and easy-to-use library inspired by Python's NumPy library.
 
 ## Operations
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -103,7 +103,7 @@ void main() {
   print(fill);
 
   // compare object
-  var compare = m2d.compareobject(arr, '>', 2);
+  var compare = m2d.compare(arr,'>=', 2);
   print(compare);
 
   // concatenate

--- a/lib/src/extension/extension.dart
+++ b/lib/src/extension/extension.dart
@@ -24,4 +24,7 @@ extension Matrix2dExtension on List {
 
   /// find max value of given matrix
   List max({int? axis}) => Matrix2d().max(this, axis: axis);
+
+  /// flip (`reverse`) the matrix along the given axis and returns the modified array.
+  List flip({int? axis}) => Matrix2d().reverse(this, axis);
 }

--- a/lib/src/matrix2d.dart
+++ b/lib/src/matrix2d.dart
@@ -289,10 +289,9 @@ class Matrix2d {
     var res = [];
 
     /// compar shape length
-    if (shape.length < 2)
-
-      /// throw error
+    if (shape.length < 2) {
       throw ('Currently support 2D operations or put that values inside a list of list');
+    }
 
     /// start row loop
     for (var i = 0; i < shape[0]; i++) {
@@ -305,9 +304,7 @@ class Matrix2d {
         }
       }
     }
-
-    /// return the new diaglonal list inside list
-    return [res];
+    return res.toList();
   }
 
   /// Just like `zeros()` and `ones()` this function will return a new array of given shape, with given object(anything btw strings too)
@@ -321,13 +318,13 @@ class Matrix2d {
       List.filled(row, value).map((e) => List.filled(cols, value)).toList();
 
   /// compare values inside an array with given object and operations. function will return a  new boolen array
-  ///
   /// ```
   /// var arr = [[1,1,1],[2,2,2],[3,3,3]];
   /// var compare = m2d.compare(arr,'>',2);
   ///print(compare);
   /////[[false, false, false], [false, false, false], [true, true, true]]
   /// ```
+  @Deprecated('Use `compare` instead.')
   List compareobject(List list, String operations, object) {
     var shapee = shape(list);
     var operatns = ['>', '<', '>=', '<=', '==', '!='];
@@ -388,11 +385,66 @@ class Matrix2d {
     return res;
   }
 
+  /// compare values inside an array with given object and operations. function will return a  new boolen array
+  /// ```
+  /// var arr = [[1,1,1],[2,2,2],[3,3,3]];
+  /// var compare = m2d.compare(arr,'>',2);
+  ///print(compare);
+  /////[[false, false, false], [false, false, false], [true, true, true]]
+  /// ```
+  List compare(List list, String operation, object) {
+    var shapee = this.shape(list);
+    if (!_checkArray(list)) {
+      throw new Exception('Uneven array dimension');
+    }
+
+    if (shapee.length < 2) {
+      throw new Exception(
+          'Currently support 2D operations or put that values inside a list of list');
+    }
+    var res = fill(shapee[0], shapee[1], true);
+    for (var i = 0; i < shapee[0]; i++) {
+      for (var j = 0; j < shapee[1]; j++) {
+        try {
+          var val = list[i][j];
+          switch (operation) {
+            case '>':
+              res[i][j] = val > object;
+              break;
+            case '<':
+              res[i][j] = val < object;
+              break;
+            case '>=':
+              res[i][j] = val >= object;
+              break;
+            case '<=':
+              res[i][j] = val <= object;
+              break;
+            case '==':
+              res[i][j] = val == object;
+              break;
+            case '!=':
+              res[i][j] = val != object;
+              break;
+            default:
+              throw new Exception('Current operation is not support');
+          }
+        } catch (e) {
+          throw new Exception(
+              'Sorry can\'t compare string with number (Not javascript)');
+        }
+      }
+    }
+    return res;
+  }
+
   /// Concatenation refers to joining. This function is used to join two arrays of the same shape along a specified axis. The function takes the following parameters
   /// note: Axis along which arrays have to be joined. Default is 0
   /// note 2: concatenation of n number of arrays comming soon.....
   List concatenate(List list1, list2, {int axis = 0}) {
-    if (axis > 1 || axis < 0) throw ('axis only support 0 and 1');
+    if (axis > 1 || axis < 0) {
+      throw ('axis only support 0 and 1');
+    }
     var shape1 = shape(list1);
     var shape2 = shape(list2);
     if (axis == 1) {
@@ -472,7 +524,9 @@ class Matrix2d {
   /// axis is null by default to find max values of columns use zero and for rows use 1
   List max(List list, {int? axis}) {
     try {
-      if (!_checkArray(list)) throw new Exception('Not 2d array');
+      if (!_checkArray(list)) {
+        throw new Exception('Not 2d array');
+      }
       var result = [];
       if (axis == null) {
         list = flatten(list);
@@ -502,8 +556,8 @@ class Matrix2d {
     }
   }
 
-  /// Function used to reverse 2D array along axis 
-  /// axis is 0 by default and only support 0 and 1 
+  /// Function used to reverse 2D array along axis
+  /// axis is 0 by default and only support 0 and 1
   /// ```dart
   /// var arr = [[1,2,3],[4,5,6],[7,8,9]];
   /// var res = m2d.reverse(arr);
@@ -515,9 +569,9 @@ class Matrix2d {
       return list.reversed.toList();
     } else if (axis == 1) {
       var temp = [];
-      for (var i = 0; i < list.length; i++) {
-        temp.add(list[i].reversed.toList());
-      }
+      list.forEach((element) {
+        temp.add(element.reversed.toList());
+      });
       return temp;
     } else {
       throw new Exception('Only two axis 0 and 1');

--- a/lib/src/matrix2d.dart
+++ b/lib/src/matrix2d.dart
@@ -502,6 +502,28 @@ class Matrix2d {
     }
   }
 
+  /// Function used to reverse 2D array along axis 
+  /// axis is 0 by default and only support 0 and 1 
+  /// ```dart
+  /// var arr = [[1,2,3],[4,5,6],[7,8,9]];
+  /// var res = m2d.reverse(arr);
+  /// print(res);
+  /// // [[7,8,9],[4,5,6],[1,2,3]]
+  /// ```
+  List reverse(List<dynamic> list, [axis = 0]) {
+    if (axis == 0) {
+      return list.reversed.toList();
+    } else if (axis == 1) {
+      var temp = [];
+      for (var i = 0; i < list.length; i++) {
+        temp.add(list[i].reversed.toList());
+      }
+      return temp;
+    } else {
+      throw new Exception('Only two axis 0 and 1');
+    }
+  }
+
   /// Function used to slice two-dimensional arrays
   ///
   /// slice(parent array, row_index [start, stop], column_index [start, stop])

--- a/lib/src/matrix2d.dart
+++ b/lib/src/matrix2d.dart
@@ -79,21 +79,16 @@ class Matrix2d {
   ///// [[1,1],[2,2]]
   ///```
   List transpose(List list) {
-    final _shapeCheck = _checkArray(list);
-    final shape = this.shape(list);
-    if (!_shapeCheck) throw new Exception('Uneven array dimension');
-    var temp =
-        List.filled(shape[1], 0).map((e) => List.filled(shape[0], 0)).toList();
-    for (var i = 0; i < list.length; i++) {
-      if (list[i] is List) {
-        for (var j = 0; j < list[i].length; j++) {
-          temp[j][i] = list[i][j];
-        }
-      } else {
-        temp[0][i] = list[i];
+    if (!_checkArray(list)) throw new Exception('Uneven array dimension');
+    var result = [];
+    for (var i = 0; i < list[0].length; i++) {
+      var temp = [];
+      for (var j = 0; j < list.length; j++) {
+        temp.add(list[j][i]);
       }
+      result.add(temp);
     }
-    return temp;
+    return result;
   }
 
   /// Function is used when we want to compute the addition of two array.

--- a/lib/src/matrix2d.dart
+++ b/lib/src/matrix2d.dart
@@ -62,8 +62,10 @@ class Matrix2d {
     if (!_shapeCheck) throw new Exception('Uneven array dimension');
     var result = [];
     for (var i = 0; i < list.length; i++) {
-      for (var j = 0; j < list[i].length; j++) {
-        result.add(list[i][j]);
+      if (list[i] is List) {
+        result.addAll(list[i]);
+      } else {
+        result.add(list[i]);
       }
     }
     return result;
@@ -80,13 +82,15 @@ class Matrix2d {
     final _shapeCheck = _checkArray(list);
     final shape = this.shape(list);
     if (!_shapeCheck) throw new Exception('Uneven array dimension');
-    // todo add zero here
     var temp =
         List.filled(shape[1], 0).map((e) => List.filled(shape[0], 0)).toList();
-    ;
-    for (var i = 0; i < shape[1]; i++) {
-      for (var j = 0; j < shape[0]; j++) {
-        temp[i][j] = list[j][i];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i] is List) {
+        for (var j = 0; j < list[i].length; j++) {
+          temp[j][i] = list[i][j];
+        }
+      } else {
+        temp[0][i] = list[i];
       }
     }
     return temp;
@@ -226,9 +230,9 @@ class Matrix2d {
   /// print(sum);
   /// //8
   ///```
-  sum(List list) {
+  num sum(List list) {
     var listShape = shape(list);
-    if (listShape[0] != 1 || listShape[0] == 1) list = flatten(list);
+    if (listShape[0] != 1 || listShape[0] == 1) list = this.flatten(list);
     return utlArrSum(list);
   }
 
@@ -239,20 +243,15 @@ class Matrix2d {
   ///print(reshape);
   /////[[0, 1, 2, 3], [4, 5, 6, 7]]
   ///```
-  reshape(List list, int row, int column) {
+  List reshape(List list, int row, int column) {
     var listShape = shape(list);
     if (listShape[0] != 1 || listShape[0] == 1) list = flatten(list);
     var copy = list.sublist(0);
     list.clear();
-    for (var r = 0; r < row; r++) {
-      var res = [];
-      for (var c = 0; c < column; c++) {
-        var i = r * column + c;
-        if (i < copy.length) {
-          res.add(copy[i]);
-        }
-      }
-      list.add(res);
+    for (var i = 0; i < copy.length; i++) {
+      var r = i ~/ column;
+      if (list.length <= r) list.add([]);
+      list[r].add(copy[i]);
     }
     return list;
   }
@@ -282,29 +281,15 @@ class Matrix2d {
   /////[[1,2,3]]
   ///```
   List diagonal(List list) {
-    /// get the shape on an given array
     final shape = this.shape(list);
-
-    /// initialize empty array
     var res = [];
-
-    /// compar shape length
     if (shape.length < 2) {
       throw ('Currently support 2D operations or put that values inside a list of list');
     }
-
-    /// start row loop
     for (var i = 0; i < shape[0]; i++) {
-      /// start column loops
-      for (var j = 0; j < shape[1]; j++) {
-        /// compare row to column
-        if (i == j) {
-          /// if true add list value to initialized list
-          res.add(list[i][j]);
-        }
-      }
+      res.add(list[i][i]);
     }
-    return res.toList();
+    return res;
   }
 
   /// Just like `zeros()` and `ones()` this function will return a new array of given shape, with given object(anything btw strings too)
@@ -450,24 +435,8 @@ class Matrix2d {
     if (axis == 1) {
       if (shape1[0] == shape2[0]) {
         var temp = fill(shape1[0], shape1[1] + shape2[1], null);
-        var jwal = shape1[1] >= shape2[1] ? shape1[1] : shape2[1];
         for (var i = 0; i < shape1[0]; i++) {
-          for (var j = 0; j < jwal; j++) {
-            if (shape1[1] == shape2[1]) {
-              temp[i][j] = list1[i][j];
-              temp[i][j + shape2[1]] = list2[i][j];
-            } else if (shape1[1] > shape2[1]) {
-              temp[i][j] = list1[i][j];
-              if (j < shape2[1]) {
-                temp[i][j + shape1[1]] = list2[i][j];
-              }
-            } else {
-              if (j < shape1[1]) {
-                temp[i][j] = list1[i][j];
-              }
-              temp[i][j + shape2[1] - (shape2[1] - shape1[1])] = list2[i][j];
-            }
-          }
+          temp[i] = list1[i] + list2[i];
         }
         return temp;
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,10 @@
 name: matrix2d
-description: A numpy-like package for mathematical 2d array functions and manipulations for dart
+description: Matrix 2D is a package for mathematical 2D array functions and manipulations in Dart, similar to NumPy
 version: 1.0.4
 homepage: 'https://github.com/n4ze3m/matrix2d'
 
 environment:
   sdk: '>=2.12.0-133.2.beta <3.0.0'
 
-# dependencies:
-#   statistical_dart: ^0.0.3
-  
 dev_dependencies:
   test: ^1.7.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: matrix2d
 description: A numpy-like package for mathematical 2d array functions and manipulations for dart
-version: 1.0.3
+version: 1.0.4
 homepage: 'https://github.com/n4ze3m/matrix2d'
 
 environment:

--- a/test/util/matrix2d_test.dart
+++ b/test/util/matrix2d_test.dart
@@ -14,14 +14,65 @@ void main() {
     expect(m2d.flatten(array), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 5, 7, 8, 9, 10]);
   });
 
-  test('test transpose', () {
-    expect(m2d.transpose(array), [
-      [1, 6, 5],
-      [2, 7, 7],
-      [3, 8, 8],
-      [4, 9, 9],
-      [5, 10, 10]
-    ]);
+  test('test transpose with double', () {
+    expect(
+        m2d.transpose([
+          [1.0, 2.0],
+          [1.0, 2.0]
+        ]),
+        [
+          [1.0, 1.0],
+          [2.0, 2.0]
+        ]);
+  });
+
+  test('test transpose with int', () {
+    expect(
+        m2d.transpose([
+          [1, 2],
+          [1, 2]
+        ]),
+        [
+          [1, 1],
+          [2, 2]
+        ]);
+  });
+
+  test('test transpose with string', () {
+    expect(
+        m2d.transpose([
+          ['1', '2'],
+          ['1', '2']
+        ]),
+        [
+          ['1', '1'],
+          ['2', '2']
+        ]);
+  });
+
+  test('test transpose with bool', () {
+    expect(
+        m2d.transpose([
+          [true, false],
+          [true, false]
+        ]),
+        [
+          [true, true],
+          [false, false]
+        ]);
+  });
+
+  test('test transpose with dynamic', () {
+    expect(
+        m2d.transpose([
+          [1, '2', true],
+          [1, '2', false]
+        ]),
+        [
+          [1, 1],
+          ['2', '2'],
+          [true, false]
+        ]);
   });
 
   test('test reshape', () {

--- a/test/util/matrix2d_test.dart
+++ b/test/util/matrix2d_test.dart
@@ -32,4 +32,19 @@ void main() {
   test('test #4', () {
     expect(m2d.slice(array, [0, 4], [3]), [4, 9, 9]);
   });
+
+  test('test #5 flip matrix axis - 0', () {
+    expect(m2d.reverse(array), [
+      [5, 7, 8, 9, 10],
+      [6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5]
+    ]);
+  });
+  test('test #6 flip matrix axis - 1', () {
+    expect(m2d.reverse(array, 1), [
+      [5, 4, 3, 2, 1],
+      [10, 9, 8, 7, 6],
+      [10, 9, 8, 7, 5]
+    ]);
+  });
 }

--- a/test/util/matrix2d_test.dart
+++ b/test/util/matrix2d_test.dart
@@ -10,11 +10,54 @@ void main() {
     [5, 7, 8, 9, 10]
   ];
 
+  test('test flatten', () {
+    expect(m2d.flatten(array), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 5, 7, 8, 9, 10]);
+  });
+
+  test('test transpose', () {
+    expect(m2d.transpose(array), [
+      [1, 6, 5],
+      [2, 7, 7],
+      [3, 8, 8],
+      [4, 9, 9],
+      [5, 10, 10]
+    ]);
+  });
+
+  test('test reshape', () {
+    expect(m2d.reshape(array, 5, 3), [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [10, 5, 7],
+      [8, 9, 10]
+    ]);
+  });
+
   test('test #1 with 2 row and column indexs', () {
     expect(m2d.slice(array, [0, 2], [1, 4]), [
       [2, 3, 4],
       [7, 8, 9]
     ]);
+  });
+
+  test('test diagonal', () {
+    expect(m2d.diagonal(array), [1, 7, 8]);
+  });
+
+  test('test concatenate', () {
+    expect(
+        m2d.concatenate([
+          [1, 2],
+          [3, 4]
+        ], [
+          [5, 6]
+        ]),
+        [
+          [1, 2],
+          [3, 4],
+          [5, 6]
+        ]);
   });
 
   test('test #2 with 1 row and 2 column index', () {


### PR DESCRIPTION
- `reverse`  method added
- `comparseobject` deprecated in favor of `compare`
- *`concatenate`, `diagonal`, `reshape`, `transpose` and `flatten` are vectorized now  (https://github.com/n4ze3m/matrix2d/issues/8)


*experimental